### PR TITLE
uninstall / move to taoProctoring

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -21,26 +21,16 @@
 
 return array(
     'name' => 'taoTestCenter',
-    'label' => 'Test Center',
-    'description' => '',
+    'label' => 'Test Center (deprecated)',
+    'description' => 'Now part of the taoProctoring',
     'license' => 'GPL-2.0',
-    'version' => '0.1.2',
+    'version' => '0.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
-        'tao' => '>=2.8.0',
-        'taoDelivery' => '>=2.7.0',
-        'taoTestTaker' => '>=2.6.0',
         'taoProctoring' => '>=0.2'
     ),
-    'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#TestCenterManager',
-    'acl' => array(
-        array('grant', 'http://www.tao.lu/Ontologies/generis.rdf#TestCenterManager', array('ext' => 'taoTestCenter')),
-    ),
-    'install' => array(
-        'rdf' => array(
-            dirname(__FILE__) . '/scripts/install/ontology/taotestcenter.rdf'
-        )
-    ),
+    'acl' => array(),
+    'install' => array(),
     'update' => 'oat\\taoTestCenter\\scripts\\update\\Updater',
     'uninstall' => array(),
     'routes' => array(
@@ -53,8 +43,5 @@ return array(
         'BASE_URL' => ROOT_URL . 'taoTestCenter/',
         #BASE WWW required by JS
         'BASE_WWW' => ROOT_URL . 'taoTestCenter/views/'
-    ),
-    'extra' => array(
-        'structures' => dirname(__FILE__) . DIRECTORY_SEPARATOR . 'controller' . DIRECTORY_SEPARATOR . 'structures.xml',
     )
 );

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -44,6 +44,20 @@ class Updater extends \common_ext_ExtensionUpdater
             $current = '0.1.2';
         }
 
+        if ($current == '0.1.2') {
+            OntologyUpdater::syncModels();
+
+            $accessService = \funcAcl_models_classes_AccessService::singleton();
+            $roleService = \tao_models_classes_RoleService::singleton();
+
+            $testCenterManager = new \core_kernel_classes_Resource('http://www.tao.lu/Ontologies/generis.rdf#TestCenterManager');
+            //revoke access right to test center manager
+            $accessService->revokeExtensionAccess($testCenterManager, 'taoTestCenter');
+            $roleService->removeRole($testCenterManager);
+
+            $current = '0.2';
+        }
+
         return $current;
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-1873

Requires: https://github.com/oat-sa/extension-tao-proctoring/pull/35

Replacement of taoTestCenter by taoProctoring
