### PR TITLE
Fix/tao 6640/assign app key to proctor

### DIFF
--- a/controller/ProctorManager.php
+++ b/controller/ProctorManager.php
@@ -233,6 +233,16 @@ class ProctorManager extends SimplePageModule
                     if(!empty($testCenters)){
                         ProctorManagementService::singleton()->authorizeProctors(array($proctor->getUri()), $testCenters);
                     }
+
+                    //assigning app key to add chance to decrypt testsessions
+                    $tcAdminUser = \common_session_SessionManager::getSession()->getUser();
+                    $userResource = new \core_kernel_classes_Resource($tcAdminUser->getIdentifier());
+                    $appKeyProperty = new \core_kernel_classes_Property('http://www.tao.lu/Ontologies/TAODelivery.rdf#applicationKey');
+
+                    $appKey = $userResource->getOnePropertyValue($appKeyProperty);
+                    if (!empty($appKey)) {
+                        $proctor->setPropertyValue($appKeyProperty, $appKey);
+                    }
                 }
             }else{
                 $form = $myForm->render();

--- a/manifest.php
+++ b/manifest.php
@@ -40,7 +40,7 @@ return array(
     'label' => 'Test Center',
     'description' => 'Proctoring via test-centers',
     'license' => 'GPL-2.0',
-    'version' => '3.18.1',
+    'version' => '3.18.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoProctoring' => '>=8.9.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -317,6 +317,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('3.18.0');
         }
 
-        $this->skip('3.18.0', '3.18.1');
+        $this->skip('3.18.0', '3.18.2');
     }
 }


### PR DESCRIPTION
Adding app key from test center administator (if he has one) to test center proctor on proctor creation. This will allow proctor not to only authorize sessions for first time, but reauthorize/terminate session/report irregularity also. As for now it was not working as newly created proctors doesn't have appkey, and from so they couldn't retrieve/decrypt test session. Possibly, this will need recompile/rebuid of VM.
Additional info on step to reproduce is in ticket for TAO-6640