### PR TITLE
Fix/remove unused variable

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -40,7 +40,7 @@ return array(
     'label' => 'Test Center',
     'description' => 'Proctoring via test-centers',
     'license' => 'GPL-2.0',
-    'version' => '3.19.0',
+    'version' => '3.19.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoProctoring' => '>=8.9.0',

--- a/model/import/RdsEligibilityImportService.php
+++ b/model/import/RdsEligibilityImportService.php
@@ -57,11 +57,6 @@ class RdsEligibilityImportService extends AbstractImportService
         $eligibility = reset($eligibilities);
 
         $testTakers = $properties[EligibilityService::PROPERTY_TESTTAKER_URI];
-        $testTakersIds = [];
-        /** @var core_kernel_classes_Resource $testTaker */
-        foreach ($testTakers as $testTaker) {
-            $testTakersIds[] = $testTaker->getUri();
-        }
 
         $this->eligibilityService->setEligibleTestTakers($testCenter, $delivery, $testTakers);
 

--- a/model/import/RdsEligibilityImportService.php
+++ b/model/import/RdsEligibilityImportService.php
@@ -25,6 +25,7 @@ use oat\tao\model\import\service\AbstractImportService;
 use oat\tao\model\import\service\ImportMapperInterface;
 use oat\taoTestCenter\model\EligibilityService;
 use core_kernel_classes_Resource;
+use oat\taoTestCenter\scripts\tools\TmpKvTable;
 
 class RdsEligibilityImportService extends AbstractImportService
 {
@@ -58,7 +59,15 @@ class RdsEligibilityImportService extends AbstractImportService
 
         $testTakers = $properties[EligibilityService::PROPERTY_TESTTAKER_URI];
 
-        $this->eligibilityService->setEligibleTestTakers($testCenter, $delivery, $testTakers);
+        $tmpkvTable = new TmpKvTable();
+        $this->propagate($tmpkvTable);
+
+        $testTakersUris = [];
+        foreach ($testTakers as $ttLogin) {
+            $testTakersUris[] = $tmpkvTable->lookup($ttLogin);
+        }
+
+        $this->eligibilityService->setEligibleTestTakers($testCenter, $delivery, $testTakersUris);
 
         if (isset($properties[EligibilityService::PROPERTY_BYPASSPROCTOR_URI])) {
             $byPass = !boolval($properties[EligibilityService::PROPERTY_BYPASSPROCTOR_URI]);

--- a/scripts/tools/MappTestTakerToKV.php
+++ b/scripts/tools/MappTestTakerToKV.php
@@ -37,7 +37,7 @@ class MappTestTakerToKV extends ScriptAction
     public function run()
     {
         $limit = $this->getOption('limit');
-        $offset = 0;
+        $offset = $this->getOption('offset');
 
         $report = Report::createInfo('Mapping TestTakers logins');
 
@@ -93,6 +93,13 @@ class MappTestTakerToKV extends ScriptAction
                 'cast'        => 'integer',
                 'required'    => true,
                 'description' => 'Limit to get tt.'
+            ],
+            'offset' => [
+                'prefix'      => 'o',
+                'longPrefix'  => 'offset',
+                'cast'        => 'integer',
+                'required'    => true,
+                'description' => 'Offset to get tt.'
             ]
         ];
     }

--- a/scripts/tools/MappTestTakerToKV.php
+++ b/scripts/tools/MappTestTakerToKV.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 Open Assessment Technologies SA
+ */
+
+namespace oat\taoTestCenter\scripts\tools;
+
+use common_persistence_KeyValuePersistence;
+use oat\generis\model\OntologyAwareTrait;
+use oat\generis\model\user\UserRdf;
+use oat\oatbox\extension\InstallAction;
+use oat\tao\model\TaoOntology;
+use oat\tao\model\user\TaoRoles;
+use common_report_Report as Report;
+
+class MappTestTakerToKV extends InstallAction
+{
+    use OntologyAwareTrait;
+
+    /**
+     * @param $params
+     * @throws \Exception
+     */
+    public function __invoke($params)
+    {
+        $report = Report::createInfo('Mapping TestTakers logins');
+
+        $class = $this->getClass(TaoOntology::CLASS_URI_SUBJECT);
+
+        $tmpkvTable = new TmpKvTable();
+        $this->propagate($tmpkvTable);
+
+        $results = $class->searchInstances(
+            [ UserRdf::PROPERTY_ROLES => TaoRoles::DELIVERY ],
+            [ 'like' => false]
+        );
+
+        foreach ($results as $result) {
+            try {
+                $value = $result->getUniquePropertyValue($this->getProperty(UserRdf::PROPERTY_LOGIN) );
+
+                $key   = $value->literal;
+                $value = $result->getUri();
+
+                $tmpkvTable->add($key, $value);
+
+            } catch (\Exception $e) {
+                $report->add(Report::createFailure($e->getMessage()));
+            }
+        }
+
+        $report->add(Report::createSuccess('Everything mapped with success'));
+
+        return $report;
+    }
+}

--- a/scripts/tools/TmpKvTable.php
+++ b/scripts/tools/TmpKvTable.php
@@ -27,6 +27,8 @@ class TmpKvTable implements ServiceManagerAwareInterface
 {
     use ServiceManagerAwareTrait;
 
+    const PREFIX = 'mapper_tt_';
+
     private $persistence;
 
     /**
@@ -37,7 +39,7 @@ class TmpKvTable implements ServiceManagerAwareInterface
      */
     public function add($key, $value)
     {
-        return $this->getPersistence()->set($key, $value);
+        return $this->getPersistence()->set($this->computeKey($key), $value);
     }
 
     /**
@@ -47,7 +49,12 @@ class TmpKvTable implements ServiceManagerAwareInterface
      */
     public function lookup($key)
     {
-        return $this->getPersistence()->get($key);
+        return $this->getPersistence()->get($this->computeKey($key));
+    }
+
+    private function computeKey($key)
+    {
+        return static::PREFIX . $key;
     }
 
     /**

--- a/scripts/tools/TmpKvTable.php
+++ b/scripts/tools/TmpKvTable.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 Open Assessment Technologies SA
+ */
+
+namespace oat\taoTestCenter\scripts\tools;
+
+use common_persistence_KeyValuePersistence;
+use oat\oatbox\service\ServiceManagerAwareInterface;
+use oat\oatbox\service\ServiceManagerAwareTrait;
+
+class TmpKvTable implements ServiceManagerAwareInterface
+{
+    use ServiceManagerAwareTrait;
+
+    private $persistence;
+
+    /**
+     * @param $key
+     * @param $value
+     * @return bool
+     * @throws \Exception
+     */
+    public function add($key, $value)
+    {
+        return $this->getPersistence()->set($key, $value);
+    }
+
+    /**
+     * @param $key
+     * @return string
+     * @throws \Exception
+     */
+    public function lookup($key)
+    {
+        return $this->getPersistence()->get($key);
+    }
+
+    /**
+     * @throws \Exception
+     */
+    private function getPersistence()
+    {
+        if (is_null($this->persistence)) {
+            $persistenceId = 'mapOfflineToOnlineResultIds';
+            $persistence = $this->getServiceLocator()->get(\common_persistence_Manager::SERVICE_ID)->getPersistenceById($persistenceId);
+
+            if (!$persistence instanceof common_persistence_KeyValuePersistence) {
+                throw new \Exception('Only common_persistence_KeyValuePersistence supported');
+            }
+
+            $this->persistence = $persistence;
+        }
+
+        return $this->persistence;
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -349,5 +349,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('3.19.0');
         }
 
+        $this->skip('3.19.0', '3.19.1');
     }
 }


### PR DESCRIPTION
Purpose of this is only for import huge amount of eligibility.
First we have to remove from the config.
So instead of: 
```
 'test takers' => array(
                'http://www.tao.lu/Ontologies/TAOProctor.rdf#EligibileTestTaker' => new oat\tao\model\import\service\ArrayImportValueMapper(array(
                    'delimiter' => '|',
                    'valueMapper' => new oat\tao\model\import\service\RdsValidatorValueMapper(array(
                        'class' => 'http://www.tao.lu/Ontologies/generis.rdf#User',
                        'property' => 'http://www.tao.lu/Ontologies/generis.rdf#login'
                    ))
                ))
            )
```
we should have:
```
 'test takers' => array(
                'http://www.tao.lu/Ontologies/TAOProctor.rdf#EligibileTestTaker' => new oat\tao\model\import\service\ArrayImportValueMapper(array(
                    'delimiter' => '|',
                ))
            )
```