### PR TITLE
Feature/tao 7389/store execution context on delivery created event

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -42,7 +42,7 @@ return array(
     'label' => 'Test Center',
     'description' => 'Proctoring via test-centers',
     'license' => 'GPL-2.0',
-    'version' => '4.8.2',
+    'version' => '4.9.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoProctoring'  => '>=12.7.0',

--- a/manifest.php
+++ b/manifest.php
@@ -45,8 +45,8 @@ return array(
     'version' => '4.8.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
-        'taoProctoring'  => '>=11.0.0',
-        'taoDelivery'    => '>=11.0.0',
+        'taoProctoring'  => '>=12.7.0',
+        'taoDelivery'    => '>=12.5.0',
         'generis'        => '>=7.4.0',
         'tao'            => '>=27.0.0',
         'taoTestTaker'   => '>=4.0.0',

--- a/model/EligibilityService.php
+++ b/model/EligibilityService.php
@@ -528,8 +528,8 @@ class EligibilityService extends ConfigurableService
     }
 
     /**
-     * @param $deliveryExecution
-     * @param $testCenter
+     * @param string $deliveryExecution
+     * @param \core_kernel_classes_Resource $testCenter
      * @return DeliveryExecutionContext|null
      */
     private function createExecutionContext($deliveryExecution, $testCenter)

--- a/model/execution/TcDeliveryExecutionContext.php
+++ b/model/execution/TcDeliveryExecutionContext.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoTestCenter\model\execution;
+
+use oat\taoDelivery\model\execution\DeliveryExecutionContext;
+
+class TcDeliveryExecutionContext extends DeliveryExecutionContext
+{
+    const EXECUTION_CONTEXT_TYPE = 'test_center';
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -402,6 +402,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('4.7.0');
         }
 
-        $this->skip('4.7.0', '4.8.2');
+        $this->skip('4.7.0', '4.9.0');
     }
 }


### PR DESCRIPTION
Store delivery execution context details in monitoring data on execution created event.

Requires:
https://github.com/oat-sa/extension-tao-proctoring/pull/670
https://github.com/oat-sa/extension-tao-delivery/pull/385