### PR TITLE
Fix/tao 8387/remove all test takers from eligibility

### DIFF
--- a/controller/TestCenterManager.php
+++ b/controller/TestCenterManager.php
@@ -284,17 +284,15 @@ class TestCenterManager extends \tao_actions_SaSModule
         $success = false;
         $testCenter = $this->getCurrentInstance();
         $eligibility = $this->_getRequestEligibility();
-        if(isset($eligibility['testTakers'])){
-            foreach($eligibility['deliveries'] as $delivery){
-                $success = $this->getEligibilityService()->setEligibleTestTakers($testCenter, $delivery, $eligibility['testTakers']);
-            }
-            // Trigger ResourceUpdated event for updating updatedAt field for resource
-            $eventManager = $this->getServiceLocator()->get(EventManager::SERVICE_ID);
-            $eventManager->trigger(new ResourceUpdated($testCenter));
-        }else{
-            //nothing to save, so consider it done
-            $success = true;
+        $testTakers = isset($eligibility['testTakers']) ? $eligibility['testTakers'] : [];
+
+        foreach ($eligibility['deliveries'] as $delivery) {
+            $success = $this->getEligibilityService()->setEligibleTestTakers($testCenter, $delivery, $testTakers);
         }
+        // Trigger ResourceUpdated event for updating updatedAt field for resource
+        $eventManager = $this->getServiceLocator()->get(EventManager::SERVICE_ID);
+        $eventManager->trigger(new ResourceUpdated($testCenter));
+
         return $this->returnJson(array(
             'success' => $success
         ));

--- a/manifest.php
+++ b/manifest.php
@@ -42,7 +42,7 @@ return array(
     'label' => 'Test Center',
     'description' => 'Proctoring via test-centers',
     'license' => 'GPL-2.0',
-    'version' => '8.0.1',
+    'version' => '8.0.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoProctoring'  => '>=12.7.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -402,6 +402,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('4.7.0');
         }
 
-        $this->skip('4.7.0', '8.0.1');
+        $this->skip('4.7.0', '8.0.2');
     }
 }


### PR DESCRIPTION
Cannot remove all test takers from Eligibility

Reproduction steps:
Go to Test Center 
Select Center
Edit Eligible Deliveries
Uncheck all users
Press ok

Expected behavior:
Test takers removed from Eligibility

Actual behavior:
 All users a still checked
