### PR TITLE
TAO-8580 - fix-put-request-for-eligibility

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -42,7 +42,7 @@ return array(
     'label' => 'Test Center',
     'description' => 'Proctoring via test-centers',
     'license' => 'GPL-2.0',
-    'version' => '8.0.4',
+    'version' => '8.0.5',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoProctoring'  => '>=12.7.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -418,6 +418,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('8.0.3');
         }
 
-        $this->skip('8.0.3', '8.0.4');
+        $this->skip('8.0.3', '8.0.5');
     }
 }


### PR DESCRIPTION
Steps to reproduce:

1 Send PUT request to http://server.loc/taoTestCenter/api/eligibility with empty test takers array
Expected result: all test takers removed from eligibility

2 Send PUT  request to http://server.loc/taoTestCenter/api/eligibility without test takers param
Expected result: all test takers remained in the eligibility