### PR TITLE
TTD-18 Tests extends from `generis\test\TestCase`. All mock objects e…

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -42,7 +42,7 @@ return array(
     'label' => 'Test Center',
     'description' => 'Proctoring via test-centers',
     'license' => 'GPL-2.0',
-    'version' => '8.2.0',
+    'version' => '8.3.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoProctoring'  => '>=12.7.0',

--- a/manifest.php
+++ b/manifest.php
@@ -42,7 +42,7 @@ return array(
     'label' => 'Test Center',
     'description' => 'Proctoring via test-centers',
     'license' => 'GPL-2.0',
-    'version' => '8.3.0',
+    'version' => '9.0.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoProctoring'  => '>=12.7.0',

--- a/manifest.php
+++ b/manifest.php
@@ -47,7 +47,7 @@ return array(
     'requires' => array(
         'taoProctoring'  => '>=12.7.0',
         'taoDelivery'    => '>=12.5.0',
-        'generis'        => '>=11.2.3',
+        'generis'        => '>=12.5.0',
         'tao'            => '>=35.5.1',
         'taoTestTaker'   => '>=4.0.0',
         'taoDeliveryRdf' => '>=6.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -429,6 +429,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('8.1.0');
         }
 
-        $this->skip('8.1.0', '8.3.0');
+        $this->skip('8.1.0', '9.0.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -429,6 +429,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('8.1.0');
         }
 
-        $this->skip('8.1.0', '8.2.0');
+        $this->skip('8.1.0', '8.3.0');
     }
 }

--- a/test/integration/gui/form/ProctorUserFormFactoryTest.php
+++ b/test/integration/gui/form/ProctorUserFormFactoryTest.php
@@ -25,8 +25,9 @@ use oat\taoProctoring\model\textConverter\ProctoringTextConverter;
 use oat\taoTestCenter\model\gui\form\formFactory\FormFactory;
 use oat\taoTestCenter\model\gui\ProctorUserFormFactory;
 use tao_helpers_form_GenerisTreeForm;
+use oat\generis\test\TestCase;
 
-class ProctorUserFormFactoryTest extends \PHPUnit_Framework_TestCase
+class ProctorUserFormFactoryTest extends TestCase
 {
     public function testInvoke()
     {

--- a/test/integration/gui/form/TestCenterAdministratorUserFormFactoryTest.php
+++ b/test/integration/gui/form/TestCenterAdministratorUserFormFactoryTest.php
@@ -24,8 +24,9 @@ use oat\taoProctoring\model\textConverter\ProctoringTextConverter;
 use oat\taoTestCenter\model\gui\form\formFactory\FormFactory;
 use oat\taoTestCenter\model\gui\TestcenterAdministratorUserFormFactory;
 use tao_helpers_form_GenerisTreeForm;
+use oat\generis\test\TestCase;
 
-class TestCenterAdministratorUserFormFactoryTest extends \PHPUnit_Framework_TestCase
+class TestCenterAdministratorUserFormFactoryTest extends TestCase
 {
     public function testInvoke()
     {

--- a/test/integration/gui/form/formFactory/FormFactoryTest.php
+++ b/test/integration/gui/form/formFactory/FormFactoryTest.php
@@ -23,10 +23,10 @@ namespace oat\taoTestCenter\test\integration\gui\form\formFactory;
 use core_kernel_classes_Resource;
 use oat\taoProctoring\model\textConverter\ProctoringTextConverter;
 use oat\taoTestCenter\model\gui\form\formFactory\FormFactory;
-use PHPUnit_Framework_TestCase;
 use tao_helpers_form_GenerisTreeForm;
+use oat\generis\test\TestCase;
 
-class FormFactoryTest extends PHPUnit_Framework_TestCase
+class FormFactoryTest extends TestCase
 {
     public function testInvoke()
     {

--- a/test/unit/gui/form/TreeFormFactoryTest.php
+++ b/test/unit/gui/form/TreeFormFactoryTest.php
@@ -23,8 +23,9 @@ use core_kernel_classes_Resource;
 use oat\taoTestCenter\model\gui\form\formFactory\FormFactoryInterface;
 use oat\taoTestCenter\model\gui\form\TreeFormFactory;
 use tao_helpers_form_GenerisTreeForm;
+use oat\generis\test\TestCase;
 
-class TreeFormFactoryTest extends \PHPUnit_Framework_TestCase
+class TreeFormFactoryTest extends TestCase
 {
 
     public function testGetForms()

--- a/test/unit/import/TestCenterCsvImporterFactoryTest.php
+++ b/test/unit/import/TestCenterCsvImporterFactoryTest.php
@@ -21,8 +21,9 @@ namespace oat\taoTestCenter\test\unit\import;
 
 use oat\tao\model\import\service\ImportServiceInterface;
 use oat\taoTestCenter\model\import\TestCenterCsvImporterFactory;
+use oat\generis\test\TestCase;
 
-class TestCenterCsvImporterFactoryTest extends \PHPUnit_Framework_TestCase
+class TestCenterCsvImporterFactoryTest extends TestCase
 {
     public function testGetImporter()
     {

--- a/test/unit/model/EligibilityServiceTest.php
+++ b/test/unit/model/EligibilityServiceTest.php
@@ -26,6 +26,7 @@ use oat\generis\model\resource\exception\DuplicateResourceException;
 use oat\generis\test\TestCase;
 use oat\taoTestCenter\model\EligibilityService;
 use oat\taoTestCenter\model\TestCenterAssignment;
+use oat\generis\test\MockObject;
 
 class EligibilityServiceTest extends TestCase
 {
@@ -35,27 +36,27 @@ class EligibilityServiceTest extends TestCase
     private $eligibilityService;
 
     /**
-     * @var Ontology|\PHPUnit_Framework_MockObject_MockObject
+     * @var Ontology|MockObject
      */
     private $modelMock;
 
     /**
-     * @var core_kernel_classes_Class|\PHPUnit_Framework_MockObject_MockObject
+     * @var core_kernel_classes_Class|MockObject
      */
     private $deliveryEligibilityClassMock;
 
     /**
-     * @var core_kernel_classes_Resource|\PHPUnit_Framework_MockObject_MockObject
+     * @var core_kernel_classes_Resource|MockObject
      */
     private $delivery;
 
     /**
-     * @var core_kernel_classes_Resource|\PHPUnit_Framework_MockObject_MockObject
+     * @var core_kernel_classes_Resource|MockObject
      */
     private $testCenter;
 
     /**
-     * @var TestCenterAssignment|\PHPUnit_Framework_MockObject_MockObject
+     * @var TestCenterAssignment|MockObject
      */
     private $testCenterAssignmentMock;
 

--- a/test/unit/model/listener/DeliveryListenerTest.php
+++ b/test/unit/model/listener/DeliveryListenerTest.php
@@ -24,6 +24,7 @@ use oat\taoDeliveryRdf\model\event\DeliveryRemovedEvent;
 use oat\taoDeliveryRdf\model\event\DeliveryUpdatedEvent;
 use oat\taoTestCenter\model\EligibilityService;
 use oat\taoTestCenter\model\listener\DeliveryListener;
+use oat\generis\test\MockObject;
 
 class DeliveryListenerTest extends TestCase
 {
@@ -33,7 +34,7 @@ class DeliveryListenerTest extends TestCase
     private $deliveryListener;
 
     /**
-     * @var EligibilityService|\PHPUnit_Framework_MockObject_MockObject
+     * @var EligibilityService|MockObject
      */
     private $eligibilityServiceMock;
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TTD-18
Depends on: https://github.com/oat-sa/generis/pull/678
All tests extends `generis\test\TestCase` instead of `\PHPUnit_Framework_TestCase`
All Mock objects instances of `generis\test\MockObject` instead of `\PHPUnit_Framework_MockObject_MockObject`. Mocks was used only in phpdoc.
Possible way to test:
1) run unit tests.
2) update code.
3) run unit tests again. result should be the same as in 1.