### PR TITLE
Avoid deprecated method usage

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -42,7 +42,7 @@ return array(
     'label' => 'Test Center',
     'description' => 'Proctoring via test-centers',
     'license' => 'GPL-2.0',
-    'version' => '9.0.0',
+    'version' => '9.0.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoProctoring'  => '>=12.7.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -429,6 +429,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('8.1.0');
         }
 
-        $this->skip('8.1.0', '9.0.0');
+        $this->skip('8.1.0', '9.0.1');
     }
 }

--- a/test/unit/model/listener/DeliveryListenerTest.php
+++ b/test/unit/model/listener/DeliveryListenerTest.php
@@ -42,7 +42,7 @@ class DeliveryListenerTest extends TestCase
     {
         parent::setUp();
 
-        $this->eligibilityServiceMock = $this->getMock(EligibilityService::class);
+        $this->eligibilityServiceMock = $this->createMock(EligibilityService::class);
         $slMock = $this->getServiceLocatorMock([
             EligibilityService::SERVICE_ID => $this->eligibilityServiceMock
         ]);


### PR DESCRIPTION
Remove deprecated `TestCase::getMock()`.