### PR TITLE
Add aria-label to header

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -42,7 +42,7 @@ return array(
     'label' => 'Test Center',
     'description' => 'Proctoring via test-centers',
     'license' => 'GPL-2.0',
-    'version' => '9.1.0',
+    'version' => '9.1.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoProctoring'  => '>=12.7.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -429,6 +429,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('8.1.0');
         }
 
-        $this->skip('8.1.0', '9.1.0');
+        $this->skip('8.1.0', '9.1.1');
     }
 }

--- a/views/templates/layout.tpl
+++ b/views/templates/layout.tpl
@@ -22,7 +22,7 @@ use oat\tao\model\theme\Theme;
 <?php Template::inc('blocks/requirement-check.tpl', 'tao'); ?>
 
         <div class="content-wrap">
-            <header class="dark-bar clearfix">
+            <header aria-label="<?=__('Main Menu')?>" class="dark-bar clearfix">
                 <?= Layout::renderThemeTemplate(Theme::CONTEXT_BACKOFFICE, 'header-logo') ?>
                 <div class="lft title-box"></div>
                 <nav class="rgt">


### PR DESCRIPTION
#### Related to:
https://oat-sa.atlassian.net/browse/TCA-554
 
"Header" landmark should not have a heading, the footer is currently missing a label.
  
#### How to test

Check that:
- `<header>` tag has `aria-label=”Main Menu”`
