### PR TITLE
Disable advanced search for extension

### DIFF
--- a/migrations/Version202209260910021871_taoTestCenter.php
+++ b/migrations/Version202209260910021871_taoTestCenter.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoTestCenter\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\model\search\SearchProxy;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoTestCenter\model\TestCenterService;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202209260910021871_taoTestCenter extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Add taoTestCenter to OPTION_GENERIS_SEARCH_WHITELIST';
+    }
+
+    public function up(Schema $schema): void
+    {
+        /** @var SearchProxy $searchProxy */
+        $searchProxy = $this->getServiceManager()->get(SearchProxy::SERVICE_ID);
+
+        $searchProxy->extendGenerisSearchWhiteList(
+            [TestCenterService::CLASS_URI]
+        );
+
+        $this->registerService(SearchProxy::SERVICE_ID, $searchProxy);
+
+    }
+
+    public function down(Schema $schema): void
+    {
+        /** @var SearchProxy $searchProxy */
+        $searchProxy = $this->getServiceManager()->get(SearchProxy::SERVICE_ID);
+
+        $searchProxy->removeFromGenerisSearchWhiteList(
+            [TestCenterService::CLASS_URI]
+        );
+
+        $this->registerService(SearchProxy::SERVICE_ID, $searchProxy);
+    }
+}

--- a/scripts/install/TestCenterOverrideServices.php
+++ b/scripts/install/TestCenterOverrideServices.php
@@ -21,6 +21,8 @@
 
 namespace oat\taoTestCenter\scripts\install;
 
+use oat\oatbox\extension\InstallAction;
+use oat\tao\model\search\SearchProxy;
 use oat\tao\model\user\import\UserCsvImporterFactory;
 use oat\taoProctoring\model\authorization\TestTakerAuthorizationInterface;
 use oat\taoProctoring\model\ProctorServiceInterface;
@@ -29,23 +31,22 @@ use oat\taoTestCenter\model\proctoring\TestCenterProctorService;
 use oat\taoTestCenter\model\TestCenterAssignment;
 use oat\taoDelivery\model\AssignmentService;
 use oat\taoTestCenter\model\proctoring\TestCenterAuthorizationService;
+use oat\taoTestCenter\model\TestCenterService;
 
 /**
  * Class TestCenterOverrideServices
  * @package oat\taoTestCenter\scripts\install
  * @author Aleh Hutnikau, <hutnikau@1pt.com>
  */
-class TestCenterOverrideServices extends \common_ext_action_InstallAction
+class TestCenterOverrideServices extends InstallAction
 {
-    /**
-     * @param $params
-     */
     public function __invoke($params)
     {
         $this->registerService(AssignmentService::CONFIG_ID, new TestCenterAssignment());
         $this->registerTestTakerAuthorizationService();
         $this->registerProctorService();
         $this->registerTestCenterAdminCsvImporter();
+        $this->registerSearchService();
     }
 
     private function registerTestTakerAuthorizationService()
@@ -75,5 +76,16 @@ class TestCenterOverrideServices extends \common_ext_action_InstallAction
         $importerFactory->setOption(UserCsvImporterFactory::OPTION_MAPPERS, $typeOptions);
         $this->registerService(UserCsvImporterFactory::SERVICE_ID, $importerFactory);
         return \common_report_Report::createSuccess('TestCenterAdmin csv importer successfully registered.');
+    }
+
+    private function registerSearchService()
+    {
+        /** @var SearchProxy $searchProxy */
+        $searchProxy = $this->getServiceManager()->get(SearchProxy::SERVICE_ID);
+        $searchProxy->extendGenerisSearchWhiteList([
+            TestCenterService::CLASS_URI,
+        ]);
+
+        $this->getServiceManager()->register(SearchProxy::SERVICE_ID, $searchProxy);
     }
 }


### PR DESCRIPTION
Jira task is [REL-839](https://oat-sa.atlassian.net/browse/REL-839)

- fix: keep generis search for test center class instances
- chore: add migration with search config
