### PR TITLE
fix: correct action bar icon order weights (AUT-4491)

### DIFF
--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -18,25 +18,25 @@
                             />
                 </trees>
                 <actions allowClassActions="true">
-                    <action id="testcenter-class-properties" name="Properties" url="/taoTestCenter/TestCenterManager/editClassLabel" group="content" context="class">
+                    <action id="testcenter-class-properties" name="Properties" url="/taoTestCenter/TestCenterManager/editClassLabel" group="content" context="class" weight="10">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="testcenter-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class">
+                    <action id="testcenter-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class" weight="3">
                         <icon id="icon-property-add"/>
                     </action>
                     <action id="testcenter-properties" name="Properties" url="/taoTestCenter/TestCenterManager/editCenter"
-                            group="content" context="instance">
+                            group="content" context="instance" weight="10">
                         <icon id="icon-edit"/>
                     </action>
                     <action id="testcenter-class-new" name="New class" url="/taoTestCenter/TestCenterManager/addSubClass"
-                            context="resource" group="tree" binding="subClass">
+                            context="resource" group="tree" binding="subClass" weight="10">
                         <icon id="icon-folder-open"/>
                     </action>
                     <action id="testcenter-delete" name="Delete" url="/taoTestCenter/TestCenterManager/delete"
-                            context="resource" group="tree" binding="removeNode">
+                            context="resource" group="tree" binding="removeNode" weight="9">
                         <icon id="icon-bin"/>
                     </action>
-                    <action id="testcenter-delete-all" name="Delete" url="/taoTestCenter/TestCenterManager/deleteAll" multiple="true" context="resource" group="tree" binding="removeNodes">
+                    <action id="testcenter-delete-all" name="Delete" url="/taoTestCenter/TestCenterManager/deleteAll" multiple="true" context="resource" group="tree" binding="removeNodes" weight="9">
                         <icon id="icon-bin"/>
                     </action>
                     <action id="testcenter-move" name="Move" url="/taoTestCenter/TestCenterManager/moveInstance"
@@ -44,15 +44,15 @@
                         <icon id="icon-move-item"/>
                     </action>
                     <action id="testcenter-duplicate" name="Duplicate" url="/taoTestCenter/TestCenterManager/cloneInstance"
-                            context="instance" group="tree" binding="duplicateNode">
+                            context="instance" group="tree" binding="duplicateNode" weight="6">
                         <icon id="icon-copy"/>
                     </action>
                     <action id="testcenter-new" name="New Test Center" url="/taoTestCenter/TestCenterManager/addInstance"
-                            context="resource" group="tree" binding="instanciate">
+                            context="resource" group="tree" binding="instanciate" weight="1">
                         <icon id="icon-users"/>
                     </action>
                     <action id="testcenter-import" name="Import" url="/taoTestCenter/Import/index"
-                            context="resource" group="tree">
+                            context="resource" group="tree" weight="8">
                         <icon id="icon-import"/>
                     </action>
                 </actions>

--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -18,14 +18,14 @@
                             />
                 </trees>
                 <actions allowClassActions="true">
-                    <action id="testcenter-class-properties" name="Properties" url="/taoTestCenter/TestCenterManager/editClassLabel" group="content" context="class" weight="10">
+                    <action id="testcenter-class-properties" name="Properties" url="/taoTestCenter/TestCenterManager/editClassLabel" group="content" context="class" weight="1">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="testcenter-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class" weight="3">
+                    <action id="testcenter-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class" weight="8">
                         <icon id="icon-property-add"/>
                     </action>
                     <action id="testcenter-properties" name="Properties" url="/taoTestCenter/TestCenterManager/editCenter"
-                            group="content" context="instance" weight="10">
+                            group="content" context="instance" weight="1">
                         <icon id="icon-edit"/>
                     </action>
                     <action id="testcenter-class-new" name="New class" url="/taoTestCenter/TestCenterManager/addSubClass"


### PR DESCRIPTION
# fix: correct action bar icon order weights (AUT-4491)

## Summary

- Adds missing `weight` attributes to all action definitions in `structures.xml` files across affected extensions.
- Fixes incorrect icon order in the Actions menu (all tabs) when the QuickWins design feature flag is enabled.
- Root cause: `getSortedActionsByWeight()` in `tao/helpers/Layout.php` sorts ascending by weight; weights were never consistently set when weight-based sorting was introduced in AUT-3938.

## Weight conventions applied

### Tree actions (lower = leftmost)
| Weight | Action type |
|--------|------------|
| 10 | New class |
| 9 | Delete (instance / class / all) |
| 8 | Import |
| 7 | Export / Publish |
| 6 | Duplicate |
| 5 | Copy To |
| 4 | Move To |
| 3 | Translate |
| 1 | New [entity] (primary create action) |

### Content actions
| Weight | Action type |
|--------|------------|
| 10 | Properties (instance / class) |
| 9 | Preview |
| 8 | Authoring |
| 7 | History |
| 6 | Usage |
| 5 | Item Statistics |
| 3 | Manage Schema |

## Impacted extensions

- `extension-tao-item` (taoItems)
- `extension-tao-itemqti` (taoQtiItem)
- `extension-tao-test` (taoTests)
- `extension-tao-testqti` (taoQtiTest)
- `extension-tao-group` (taoGroups)
- `extension-tao-testtaker` (taoTestTaker)
- `extension-tao-delivery-rdf` (taoDeliveryRdf)
- `extension-tao-deliver-connect` (taoDeliverConnect)
- `extension-tao-backoffice` (taoBackOffice)
- `extension-tao-outcomeui` (taoOutcomeUi)
- `extension-tao-proctoring` (taoProctoring)
- `extension-remote-proctoring` (remoteProctoring)
- `extension-tao-lti-consumer` (taoLtiConsumer)
- `extension-tao-testcenter` (taoTestCenter)
- `extension-tao-blueprints` (taoBlueprints)
- `extension-tao-mediamanager` (taoMediaManager)

## Testing

Enable the QuickWins design feature flag and verify the Actions toolbar icons appear in the correct order on all tabs (Items, Tests, Test-Takers, Groups, Deliveries, Results, Assets, Blueprints, Test Centers).

No code logic changes — XML `weight` attribute additions/corrections only.

## Related

- Jira: AUT-4491
- Introduced by: AUT-3938 (weight-based sort added to Layout.php)